### PR TITLE
Rahimi and Recht approx

### DIFF
--- a/examples/make_synthetic_data.py
+++ b/examples/make_synthetic_data.py
@@ -60,4 +60,9 @@ def generate_data(n=100, datatype='', seed = 0):
 
         y = -2 * np.sin(2*X[:,0]) + np.maximum(X[:,1], 0) + X[:,2] + np.exp(-X[:,3]) + np.random.randn(n) 
 
+    elif datatype == 'regression_approx': 
+        X = np.random.randn(n, 10) 
+
+        y = -2 * np.sin(2*X[:,0]) + np.maximum(X[:,1], 0) + X[:,2] + np.exp(-X[:,3]) + np.random.randn(n) 
+
     return (X, y) 

--- a/examples/run_synthetic.py
+++ b/examples/run_synthetic.py
@@ -35,3 +35,11 @@ epsilon = 0.1; num_features = 4; type_Y = 'real-valued'
 rank = ccm.ccm(X, Y, num_features, type_Y, epsilon, verbose = False) 
 selected_feats = np.argsort(rank)[:4]
 print('The four features selected by CCM on the nonlinear regression dataset are features {}'.format(selected_feats))
+
+print('-------------------------------------------')
+print('Running CCM on the approximate nonlinear regression dataset...')
+X, Y = generate_data(n=100, datatype='regression_approx', seed = 0)
+epsilon = 0.1; num_features = 4; type_Y = 'real-valued'
+rank = ccm.ccm(X, Y, num_features, type_Y, epsilon, D_approx=5, verbose = False) 
+selected_feats = np.argsort(rank)[:4]
+print('The four features selected by CCM on the approximate nonlinear regression dataset are features {}'.format(selected_feats))


### PR DESCRIPTION
core/ccm.py: implement rank-D approximate kernel evaluations, arXiv:1707.01164 eq. 21

examples/: add 'regression_approx' dataset and 'approximate nonlinear regression' test case for rank-D approximate kernel evaluations

Tested and works well for large datasets.